### PR TITLE
Handle an empty service_id list in cloudi_service_api:services_remove/2

### DIFF
--- a/src/cloudi_service_api.erl
+++ b/src/cloudi_service_api.erl
@@ -373,6 +373,8 @@ services_add([_ | _] = L, Timeout)
      timeout | noproc |
      cloudi_configuration:error_reason_services_remove()}.
 
+services_remove([], _Timeout) ->
+    ok;
 services_remove([_ | _] = L, Timeout)
     when ((is_integer(Timeout) andalso
            (Timeout > ?TIMEOUT_DELTA) andalso


### PR DESCRIPTION
`cloudi_service_api:services_remove/2` won't match against:

`cloudi_service_api:services_remove([],Timeout)`

If there's possibility that the service list you pass is empty, you must use handle it with awkward `case`:

<pre>
Result = case ServiceIdList of 
    [ ] ->
        ok;
    [ _ : _ ] ->
        cloudi_service_api:services_remove(ServiceIdList,Timeout)
end.
</pre>


It seems easier to handle the empty list case in `cloudi_service_api`.
